### PR TITLE
Remove an erroneous double space in a French translation string

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -137,7 +137,7 @@ fr:
         other: Communiqués
     metadata:
       published: publié
-      updated: mise à  jour
+      updated: mise à jour
     contents:
   detailed_guide:
     related_mainstream_content:


### PR DESCRIPTION
- I can't think of any reason why « mise à jour » needs an extra space in it.